### PR TITLE
[UPDATE][FACECHANGE] Support MultiFace Change

### DIFF
--- a/examples/lite/cv/test_lite_facefusion_pipeline.cpp
+++ b/examples/lite/cv/test_lite_facefusion_pipeline.cpp
@@ -64,7 +64,7 @@ static void test_tensorrt()
     // 写一个测试时间的代码
     auto start = std::chrono::high_resolution_clock::now();
 
-    pipeLine.detect(source_image_path,target_image_path,save_image_path);
+    pipeLine.detect(source_image_path,0,target_image_path,0,save_image_path);
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> diff = end-start;
     std::cout << "Time: " << diff.count()  * 1000<< " ms\n";

--- a/examples/lite/cv/test_lite_facefusion_pipeline.cpp
+++ b/examples/lite/cv/test_lite_facefusion_pipeline.cpp
@@ -64,7 +64,9 @@ static void test_tensorrt()
     // 写一个测试时间的代码
     auto start = std::chrono::high_resolution_clock::now();
 
+//    pipeLine.detect(source_image_path,target_image_path,save_image_path);
     pipeLine.detect(source_image_path,0,target_image_path,0,save_image_path);
+
     auto end = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> diff = end-start;
     std::cout << "Time: " << diff.count()  * 1000<< " ms\n";

--- a/lite/trt/cv/trt_facefusion_pipeline.cpp
+++ b/lite/trt/cv/trt_facefusion_pipeline.cpp
@@ -19,8 +19,10 @@ TRTFaceFusionPipeLine::TRTFaceFusionPipeLine(const std::string &face_detect_engi
 
 }
 
-void TRTFaceFusionPipeLine::detect(const std::string &source_image, const std::string &target_image,
-                                   const std::string &save_image) {
+
+
+void TRTFaceFusionPipeLine::detect(const std::string &source_image, int src_index, const std::string &target_image,
+                                   int target_index, const std::string &save_image) {
     // source 的全部流程
     // image -> detect -> landmarks -> recognizer -> embeding
     // 最终也就是 image -> embeding
@@ -28,10 +30,26 @@ void TRTFaceFusionPipeLine::detect(const std::string &source_image, const std::s
     cv::Mat img_bgr = cv::imread(source_image);
     auto img_bgr_src = img_bgr.clone();
     face_detect->detect(img_bgr,detected_boxes,0.25f,0.45f);
-    int position = 0; // position number 0
-    auto test_bounding_box = detected_boxes[0];
+
+    std::vector<lite::types::Boxf> src_final_boxes;
+    for (auto current_box : detected_boxes)
+    {
+        if (current_box.score != 0)
+        {
+            src_final_boxes.emplace_back(current_box);
+        }
+    }
+
+
+
     std::vector<cv::Point2f> face_landmark_5of68;
-    face_landmarks->detect(img_bgr, test_bounding_box,face_landmark_5of68);
+
+    if (src_final_boxes.size()==1)
+    {
+        face_landmarks->detect(img_bgr, src_final_boxes[0],face_landmark_5of68);
+    }else{
+        face_landmarks->detect(img_bgr, src_final_boxes[src_index],face_landmark_5of68);
+    }
 
     // 这里准备使用多线程来进行操作 因为这里的操作和下面target的操作是独立的
     // 这段代码仅仅是为了测试多线程的效果
@@ -54,14 +72,29 @@ void TRTFaceFusionPipeLine::detect(const std::string &source_image, const std::s
     cv::Mat target_img_bgr = cv::imread(target_image);
     auto target_img_bgr_src = target_img_bgr.clone();
     face_detect->detect(target_img_bgr, target_detected_boxes,0.25f,0.45f);
-    auto target_test_bounding_box = target_detected_boxes[0];
+
+    std::vector<lite::types::Boxf> target_final_boxes;
+    for (auto current_box : target_detected_boxes)
+    {
+        if (current_box.score != 0)
+        {
+            target_final_boxes.emplace_back(current_box);
+        }
+    }
+    auto target_test_bounding_box = target_final_boxes[target_index];
     std::vector<cv::Point2f> target_face_landmark_5of68;
 //    face68Landmarks->detect_async(target_img_bgr_src, target_test_bounding_box, target_face_landmark_5of68);
 //    face68Landmarks->wait_for_completion();
 //    face68Landmarks->shutdown();
 
-    face_landmarks->detect(target_img_bgr, target_test_bounding_box,target_face_landmark_5of68);
+//    face_landmarks->detect(target_img_bgr, target_test_bounding_box,target_face_landmark_5of68);
 
+    if (target_final_boxes.size()==1)
+    {
+        face_landmarks->detect(target_img_bgr, target_final_boxes[0],target_face_landmark_5of68);
+    }else{
+        face_landmarks->detect(target_img_bgr, target_final_boxes[target_index],target_face_landmark_5of68);
+    }
     // 公共部分
     cv::Mat face_swap_image;
     face_swap->detect(target_img_bgr,source_image_embeding,target_face_landmark_5of68,face_swap_image);

--- a/lite/trt/cv/trt_facefusion_pipeline.h
+++ b/lite/trt/cv/trt_facefusion_pipeline.h
@@ -35,7 +35,7 @@ namespace trtcv{
         std::unique_ptr<trt_face_68landmarks_mt> face_landmarks_mt;
 
     public:
-        void detect(const std::string &source_image,const std::string &target_image,const std::string &save_image);
+        void detect(const std::string &source_image,int src_index,const std::string &target_image,int target_index,const std::string &save_image);
 
     };
 }


### PR DESCRIPTION
This pull request modifies the `TRTFaceFusionPipeLine` class to enhance the face detection and fusion process by adding support for multiple detected boxes and allowing the selection of specific boxes based on their index. The main changes involve updating the `detect` method and its usage in the test file.

Key changes:

* Updated `detect` method in `TRTFaceFusionPipeLine` to include parameters for selecting specific detected boxes by index. (`lite/trt/cv/trt_facefusion_pipeline.cpp`) [[1]](diffhunk://#diff-afb69d3423d620ecb56328b43edf2fe24e05aa83c02ee9edfa9d24f1178fd94bL22-R52) [[2]](diffhunk://#diff-afb69d3423d620ecb56328b43edf2fe24e05aa83c02ee9edfa9d24f1178fd94bL57-R97)
* Modified the `detect` method signature in the header file to match the updated implementation. (`lite/trt/cv/trt_facefusion_pipeline.h`)
* Updated the test function `test_tensorrt` to use the new `detect` method signature. (`examples/lite/cv/test_lite_facefusion_pipeline.cpp`)