### PR TITLE
[Misc][Bugfix] Update Potential Bug by Half Vector

### DIFF
--- a/cmake/onnxruntime.cmake
+++ b/cmake/onnxruntime.cmake
@@ -3,7 +3,7 @@ set(OnnxRuntime_DIR ${THIRD_PARTY_PATH}/onnxruntime)
 # download from github if OnnxRuntime library is not exists
 if (NOT EXISTS ${OnnxRuntime_DIR})
     set(OnnxRuntime_Filename "onnxruntime-linux-x64-${OnnxRuntime_Version}.tgz")
-    set(OnnxRuntime_URL https://github.com/microsoft/onnxruntime/releases/download/v1.17.1/${OnnxRuntime_Filename})
+    set(OnnxRuntime_URL https://ghfast.top/https://github.com/microsoft/onnxruntime/releases/download/v1.17.1/${OnnxRuntime_Filename})
     message("[Lite.AI.Toolkit][I] Downloading onnxruntime library: ${OnnxRuntime_URL}")
     download_and_decompress(${OnnxRuntime_URL} ${OnnxRuntime_Filename} ${OnnxRuntime_DIR}) 
 else() 

--- a/lite/trt/sd/trt_unet.cpp
+++ b/lite/trt/sd/trt_unet.cpp
@@ -105,7 +105,7 @@ void TRTUNet::inference(const std::vector<std::vector<float>> &clip_output, std:
     std::transform(combined_embedding.begin(), combined_embedding.end(), combined_embedding_fp16.begin(),[](float f) { return __float2half(f);});
 
 
-    std::vector<half> latents_fp16(latents.size(),0);
+    std::vector<half> latents_fp16(latents.size(), __float2half(0));
     std::transform(latents.begin(), latents.end(), latents_fp16.begin(),[](float f) { return __float2half(f);});
 
 
@@ -191,7 +191,7 @@ void TRTUNet::inference(const std::vector<std::vector<float>> &clip_output, std:
         scheduler.step(noise_pred,noise_pred_dims, latents_fp32, noise_pred_dims,
                        pred_sample, t);
 
-        std::vector<half> pred_sample_fp16(pred_sample.size(),0);
+        std::vector<half> pred_sample_fp16(pred_sample.size(), __float2half(0));
         std::transform(pred_sample.begin(), pred_sample.end(),
                        pred_sample_fp16.begin(),[](float f) { return __float2half(f);});
 
@@ -283,7 +283,7 @@ void TRTUNet::inference(const std::vector<std::vector<float>> &clip_output, cons
     std::transform(combined_embedding.begin(), combined_embedding.end(), combined_embedding_fp16.begin(),[](float f) { return __float2half(f);});
 
 
-    std::vector<half> latents_fp16( 2 * latents.size(),0);
+    std::vector<half> latents_fp16( 2 * latents.size(), __float2half(0));
 
 //    auto latents_0 = load_binary_file("/home/lite.ai.toolkit/tensor_data.bin");
 //    latents.insert(latents_0.end(), latents_0.begin(), latents_0.end());
@@ -378,7 +378,7 @@ void TRTUNet::inference(const std::vector<std::vector<float>> &clip_output, cons
         scheduler.step(noise_pred,noise_pred_dims, latents_fp32, noise_pred_dims,
                        pred_sample, t);
 
-        std::vector<half> pred_sample_fp16(pred_sample.size(),0);
+        std::vector<half> pred_sample_fp16(pred_sample.size(), __float2half(0));
         std::transform(pred_sample.begin(), pred_sample.end(),
                        pred_sample_fp16.begin(),[](float f) { return __float2half(f);});
 

--- a/lite/trt/sd/trt_vae_encoder.cpp
+++ b/lite/trt/sd/trt_vae_encoder.cpp
@@ -46,7 +46,7 @@ TRTVaeEncoder::~TRTVaeEncoder()  {
 }
 
 void TRTVaeEncoder::inference(const std::vector<float> &input_images, std::vector<float> &output_latents) {
-    std::vector<half > vae_encoder_input(input_images.size(),0);
+    std::vector<half > vae_encoder_input(input_images.size(), __float2half(0));
     std::transform(input_images.begin(),input_images.end(),vae_encoder_input.begin(),
                    [](float x){return __float2half(x);});
 


### PR DESCRIPTION
This pull request includes several changes to the `lite/trt/sd/trt_unet.cpp` and `lite/trt/sd/trt_vae_encoder.cpp` files, as well as an update to the `cmake/onnxruntime.cmake` file. The changes primarily involve initializing vectors with the half-precision float value `__float2half(0)` instead of the integer `0`, and updating the URL for downloading the OnnxRuntime library.

### Changes to vector initialization:

* [`lite/trt/sd/trt_unet.cpp`](diffhunk://#diff-39bed796519fe9126cc53ff16d67665ce307f0ff7e0e601562f40a5b277e00a6L108-R108): Updated the initialization of `latents_fp16` and `pred_sample_fp16` vectors to use `__float2half(0)` instead of `0`. [[1]](diffhunk://#diff-39bed796519fe9126cc53ff16d67665ce307f0ff7e0e601562f40a5b277e00a6L108-R108) [[2]](diffhunk://#diff-39bed796519fe9126cc53ff16d67665ce307f0ff7e0e601562f40a5b277e00a6L194-R194) [[3]](diffhunk://#diff-39bed796519fe9126cc53ff16d67665ce307f0ff7e0e601562f40a5b277e00a6L286-R286) [[4]](diffhunk://#diff-39bed796519fe9126cc53ff16d67665ce307f0ff7e0e601562f40a5b277e00a6L381-R381)
* [`lite/trt/sd/trt_vae_encoder.cpp`](diffhunk://#diff-d5816eee947561248f707268992e2663c028e731fdfa297d8e01faef8b97eb24L49-R49): Updated the initialization of `vae_encoder_input` vector to use `__float2half(0)` instead of `0`.

### Changes to URL for OnnxRuntime library download:

* [`cmake/onnxruntime.cmake`](diffhunk://#diff-cf615a9052867e1c18b3d5bfbd5cfe09bd5ce738e1d09f9daf6f8e83b5aba26aL6-R6): Updated the URL for downloading the OnnxRuntime library to use a different mirror.